### PR TITLE
Fix parity bit generation for bits [1..7] of any given data byte

### DIFF
--- a/fast_hamming.c
+++ b/fast_hamming.c
@@ -23,8 +23,8 @@ static inline void hecc_encode_impl(const uint8_t *inbuf, uint8_t *outbuf, size_
 
         if(data & 1) {
             p1 = p1 ^ (uint8_t)i;
-            data >>= 1;
         }
+        data >>= 1;
 
         j++;
     }
@@ -146,8 +146,8 @@ static inline bool hecc_decode_impl(const uint8_t *inbuf, uint8_t *outbuf, size_
 
         if(data & 1) {
             p1 = p1 ^ (uint8_t)i;
-            data >>= 1;
         }
+        data >>= 1;
 
         j++;
     }


### PR DESCRIPTION
Upon furtehr analysis of your code it seems that you only process the LSB of each input data byte. The other bits are only processed if all lower bits are set. Any data like `uint8_t data = 0bXXXXXXX0` is processed by the code like `0b00000000`.

The bug is present in both the encode and decode code, so encoding/decoding will still work without apperant errors.