### PR TITLE
Fix log2 calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-*
 
-!*.c
-!*.h
-!*.md
-!Makefile
+Debug/
+
+.vs/

--- a/Device_Startup/saml21j18b_flash.ld
+++ b/Device_Startup/saml21j18b_flash.ld
@@ -1,0 +1,153 @@
+/**
+ * \file
+ *
+ * \brief Linker script for running in internal FLASH on the SAML21J18B
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+SEARCH_DIR(.)
+
+/* Memory Spaces Definitions */
+MEMORY
+{
+  rom      (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00040000
+  ram      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
+  lpram    (rwx) : ORIGIN = 0x30000000, LENGTH = 0x00002000
+}
+
+/* The stack size used by the application. NOTE: you need to adjust according to your application. */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : DEFINED(__stack_size__) ? __stack_size__ : 0x2000;
+
+/* Section Definitions */
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors .vectors.*))
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        /* Support C constructors, and C destructors in both user code
+           and the C library. This also provides support for C++ code. */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > rom
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > rom
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    . = ALIGN(4);
+    _etext = .;
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+    .lpram (NOLOAD):
+    {
+        . = ALIGN(8);
+        _slpram = .;
+        *(.lpram .lpram.*);
+        . = ALIGN(8);
+        _elpram = .;
+    } > lpram
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        _ezero = .;
+    } > ram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        . = . + STACK_SIZE;
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+    . = ALIGN(4);
+    _end = . ;
+}

--- a/Device_Startup/saml21j18b_sram.ld
+++ b/Device_Startup/saml21j18b_sram.ld
@@ -1,0 +1,152 @@
+/**
+ * \file
+ *
+ * \brief Linker script for running in internal SRAM on the SAML21J18B
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+SEARCH_DIR(.)
+
+/* Memory Spaces Definitions */
+MEMORY
+{
+  ram      (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
+  lpram    (rwx) : ORIGIN = 0x30000000, LENGTH = 0x00002000
+}
+
+/* The stack size used by the application. NOTE: you need to adjust according to your application. */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : DEFINED(__stack_size__) ? __stack_size__ : 0x2000;
+
+/* Section Definitions */
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors .vectors.*))
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        /* Support C constructors, and C destructors in both user code
+           and the C library. This also provides support for C++ code. */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > ram
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > ram
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    . = ALIGN(4);
+    _etext = .;
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+    .lpram (NOLOAD):
+    {
+        . = ALIGN(8);
+        _slpram = .;
+        *(.lpram .lpram.*);
+        . = ALIGN(8);
+        _elpram = .;
+    } > lpram
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        _ezero = .;
+    } > ram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        . = . + STACK_SIZE;
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+    . = ALIGN(4);
+    _end = . ;
+}

--- a/Device_Startup/startup_saml21.c
+++ b/Device_Startup/startup_saml21.c
@@ -1,0 +1,257 @@
+/**
+ * \file
+ *
+ * \brief gcc starttup file for SAML21
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#include "saml21.h"
+
+/* Initialize segments */
+extern uint32_t _sfixed;
+extern uint32_t _efixed;
+extern uint32_t _etext;
+extern uint32_t _srelocate;
+extern uint32_t _erelocate;
+extern uint32_t _szero;
+extern uint32_t _ezero;
+extern uint32_t _sstack;
+extern uint32_t _estack;
+
+/** \cond DOXYGEN_SHOULD_SKIP_THIS */
+int main(void);
+/** \endcond */
+
+void __libc_init_array(void);
+
+/* Default empty handler */
+void Dummy_Handler(void);
+
+/* Cortex-M0+ core handlers */
+void NonMaskableInt_Handler  ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void HardFault_Handler       ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void SVCall_Handler          ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void PendSV_Handler          ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void SysTick_Handler         ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+
+/* Peripherals handlers */
+void SYSTEM_Handler          ( void ) __attribute__ ((weak, alias("Dummy_Handler"))); /* MCLK, OSC32KCTRL, OSCCTRL, PAC, PM, SUPC, TAL */
+void WDT_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void RTC_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void EIC_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void NVMCTRL_Handler         ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void DMAC_Handler            ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#ifdef ID_USB
+void USB_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+void EVSYS_Handler           ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void SERCOM0_Handler         ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void SERCOM1_Handler         ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void SERCOM2_Handler         ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void SERCOM3_Handler         ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#ifdef ID_SERCOM4
+void SERCOM4_Handler         ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+#ifdef ID_SERCOM5
+void SERCOM5_Handler         ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+void TCC0_Handler            ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void TCC1_Handler            ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void TCC2_Handler            ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void TC0_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+void TC1_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#ifdef ID_TC2
+void TC2_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+#ifdef ID_TC3
+void TC3_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+void TC4_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#ifdef ID_ADC
+void ADC_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+#ifdef ID_AC
+void AC_Handler              ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+#ifdef ID_DAC
+void DAC_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+#ifdef ID_PTC
+void PTC_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+#ifdef ID_AES
+void AES_Handler             ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+#ifdef ID_TRNG
+void TRNG_Handler            ( void ) __attribute__ ((weak, alias("Dummy_Handler")));
+#endif
+
+/* Exception Table */
+__attribute__ ((section(".vectors")))
+const DeviceVectors exception_table = {
+
+        /* Configure Initial Stack Pointer, using linker-generated symbols */
+        .pvStack                = (void*) (&_estack),
+
+        .pfnReset_Handler       = (void*) Reset_Handler,
+        .pfnNonMaskableInt_Handler = (void*) NonMaskableInt_Handler,
+        .pfnHardFault_Handler   = (void*) HardFault_Handler,
+        .pvReservedM12          = (void*) (0UL), /* Reserved */
+        .pvReservedM11          = (void*) (0UL), /* Reserved */
+        .pvReservedM10          = (void*) (0UL), /* Reserved */
+        .pvReservedM9           = (void*) (0UL), /* Reserved */
+        .pvReservedM8           = (void*) (0UL), /* Reserved */
+        .pvReservedM7           = (void*) (0UL), /* Reserved */
+        .pvReservedM6           = (void*) (0UL), /* Reserved */
+        .pfnSVCall_Handler      = (void*) SVCall_Handler,
+        .pvReservedM4           = (void*) (0UL), /* Reserved */
+        .pvReservedM3           = (void*) (0UL), /* Reserved */
+        .pfnPendSV_Handler      = (void*) PendSV_Handler,
+        .pfnSysTick_Handler     = (void*) SysTick_Handler,
+
+        /* Configurable interrupts */
+        .pfnSYSTEM_Handler      = (void*) SYSTEM_Handler,         /*  0 Main Clock, 32k Oscillators Control, Oscillators Control, Peripheral Access Controller, Power Manager, Supply Controller, Trigger Allocator */
+        .pfnWDT_Handler         = (void*) WDT_Handler,            /*  1 Watchdog Timer */
+        .pfnRTC_Handler         = (void*) RTC_Handler,            /*  2 Real-Time Counter */
+        .pfnEIC_Handler         = (void*) EIC_Handler,            /*  3 External Interrupt Controller */
+        .pfnNVMCTRL_Handler     = (void*) NVMCTRL_Handler,        /*  4 Non-Volatile Memory Controller */
+        .pfnDMAC_Handler        = (void*) DMAC_Handler,           /*  5 Direct Memory Access Controller */
+#ifdef ID_USB
+        .pfnUSB_Handler         = (void*) USB_Handler,            /*  6 Universal Serial Bus */
+#else
+        .pvReserved6            = (void*) (0UL),                  /*  6 Reserved */
+#endif
+        .pfnEVSYS_Handler       = (void*) EVSYS_Handler,          /*  7 Event System Interface */
+        .pfnSERCOM0_Handler     = (void*) SERCOM0_Handler,        /*  8 Serial Communication Interface 0 */
+        .pfnSERCOM1_Handler     = (void*) SERCOM1_Handler,        /*  9 Serial Communication Interface 1 */
+        .pfnSERCOM2_Handler     = (void*) SERCOM2_Handler,        /* 10 Serial Communication Interface 2 */
+        .pfnSERCOM3_Handler     = (void*) SERCOM3_Handler,        /* 11 Serial Communication Interface 3 */
+#ifdef ID_SERCOM4
+        .pfnSERCOM4_Handler     = (void*) SERCOM4_Handler,        /* 12 Serial Communication Interface 4 */
+#else
+        .pvReserved12           = (void*) (0UL),                  /* 12 Reserved */
+#endif
+#ifdef ID_SERCOM5
+        .pfnSERCOM5_Handler     = (void*) SERCOM5_Handler,        /* 13 Serial Communication Interface 5 */
+#else
+        .pvReserved13           = (void*) (0UL),                  /* 13 Reserved */
+#endif
+        .pfnTCC0_Handler        = (void*) TCC0_Handler,           /* 14 Timer Counter Control 0 */
+        .pfnTCC1_Handler        = (void*) TCC1_Handler,           /* 15 Timer Counter Control 1 */
+        .pfnTCC2_Handler        = (void*) TCC2_Handler,           /* 16 Timer Counter Control 2 */
+        .pfnTC0_Handler         = (void*) TC0_Handler,            /* 17 Basic Timer Counter 0 */
+        .pfnTC1_Handler         = (void*) TC1_Handler,            /* 18 Basic Timer Counter 1 */
+#ifdef ID_TC2
+        .pfnTC2_Handler         = (void*) TC2_Handler,            /* 19 Basic Timer Counter 2 */
+#else
+        .pvReserved19           = (void*) (0UL),                  /* 19 Reserved */
+#endif
+#ifdef ID_TC3
+        .pfnTC3_Handler         = (void*) TC3_Handler,            /* 20 Basic Timer Counter 3 */
+#else
+        .pvReserved20           = (void*) (0UL),                  /* 20 Reserved */
+#endif
+        .pfnTC4_Handler         = (void*) TC4_Handler,            /* 21 Basic Timer Counter 4 */
+#ifdef ID_ADC
+        .pfnADC_Handler         = (void*) ADC_Handler,            /* 22 Analog Digital Converter */
+#else
+        .pvReserved22           = (void*) (0UL),                  /* 22 Reserved */
+#endif
+#ifdef ID_AC
+        .pfnAC_Handler          = (void*) AC_Handler,             /* 23 Analog Comparators */
+#else
+        .pvReserved23           = (void*) (0UL),                  /* 23 Reserved */
+#endif
+#ifdef ID_DAC
+        .pfnDAC_Handler         = (void*) DAC_Handler,            /* 24 Digital-to-Analog Converter */
+#else
+        .pvReserved24           = (void*) (0UL),                  /* 24 Reserved */
+#endif
+#ifdef ID_PTC
+        .pfnPTC_Handler         = (void*) PTC_Handler,            /* 25 Peripheral Touch Controller */
+#else
+        .pvReserved25           = (void*) (0UL),                  /* 25 Reserved */
+#endif
+#ifdef ID_AES
+        .pfnAES_Handler         = (void*) AES_Handler,            /* 26 Advanced Encryption Standard */
+#else
+        .pvReserved26           = (void*) (0UL),                  /* 26 Reserved */
+#endif
+#ifdef ID_TRNG
+        .pfnTRNG_Handler        = (void*) TRNG_Handler,           /* 27 True Random Generator */
+#else
+        .pvReserved27           = (void*) (0UL),                  /* 27 Reserved */
+#endif
+        .pvReserved28           = (void*) (0UL)                   /* 28 Reserved */
+};
+
+/**
+ * \brief This is the code that gets called on processor reset.
+ * To initialize the device, and call the main() routine.
+ */
+void Reset_Handler(void)
+{
+        uint32_t *pSrc, *pDest;
+
+        /* Initialize the relocate segment */
+        pSrc = &_etext;
+        pDest = &_srelocate;
+
+        if (pSrc != pDest) {
+                for (; pDest < &_erelocate;) {
+                        *pDest++ = *pSrc++;
+                }
+        }
+
+        /* Clear the zero segment */
+        for (pDest = &_szero; pDest < &_ezero;) {
+                *pDest++ = 0;
+        }
+
+        /* Set the vector table base address */
+        pSrc = (uint32_t *) & _sfixed;
+        SCB->VTOR = ((uint32_t) pSrc & SCB_VTOR_TBLOFF_Msk);
+
+        /* Overwriting the default value of the NVMCTRL.CTRLB.MANW bit (errata reference 13134) */
+        NVMCTRL->CTRLB.bit.MANW = 1;
+
+        /* Initialize the C library */
+        __libc_init_array();
+
+        /* Branch to main function */
+        main();
+
+        /* Infinite loop */
+        while (1);
+}
+
+/**
+ * \brief Default interrupt handler for unused IRQs.
+ */
+void Dummy_Handler(void)
+{
+        while (1) {
+        }
+}

--- a/Device_Startup/system_saml21.c
+++ b/Device_Startup/system_saml21.c
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Low-level initialization functions called upon chip startup.
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#include "saml21.h"
+
+/**
+ * Initial system clock frequency. The System RC Oscillator (RCSYS) provides
+ *  the source for the main clock at chip startup.
+ */
+#define __SYSTEM_CLOCK    (4000000)
+
+uint32_t SystemCoreClock = __SYSTEM_CLOCK;/*!< System Clock Frequency (Core Clock)*/
+
+/**
+ * Initialize the system
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System and update the SystemCoreClock variable.
+ */
+void SystemInit(void)
+{
+        // Keep the default device state after reset
+        SystemCoreClock = __SYSTEM_CLOCK;
+        return;
+}
+
+/**
+ * Update SystemCoreClock variable
+ *
+ * @brief  Updates the SystemCoreClock with current core Clock
+ *         retrieved from cpu registers.
+ */
+void SystemCoreClockUpdate(void)
+{
+        // Not implemented
+        SystemCoreClock = __SYSTEM_CLOCK;
+        return;
+}

--- a/FastHamming.atsln
+++ b/FastHamming.atsln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Atmel Studio Solution File, Format Version 11.00
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{54F91283-7BC4-4236-8FF9-10F437C3AD48}") = "FastHamming", "FastHamming.cproj", "{DCE6C7E3-EE26-4D79-826B-08594B9AD897}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
+		Release|ARM = Release|ARM
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DCE6C7E3-EE26-4D79-826B-08594B9AD897}.Debug|ARM.ActiveCfg = Debug|ARM
+		{DCE6C7E3-EE26-4D79-826B-08594B9AD897}.Debug|ARM.Build.0 = Debug|ARM
+		{DCE6C7E3-EE26-4D79-826B-08594B9AD897}.Release|ARM.ActiveCfg = Release|ARM
+		{DCE6C7E3-EE26-4D79-826B-08594B9AD897}.Release|ARM.Build.0 = Release|ARM
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/FastHamming.componentinfo.xml
+++ b/FastHamming.componentinfo.xml
@@ -1,0 +1,169 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Store xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="AtmelPackComponentManagement">
+	<ProjectComponents>
+		<ProjectComponent z:Id="i1" xmlns:z="http://schemas.microsoft.com/2003/10/Serialization/">
+			<CApiVersion></CApiVersion>
+			<CBundle></CBundle>
+			<CClass>CMSIS</CClass>
+			<CGroup>CORE</CGroup>
+			<CSub></CSub>
+			<CVariant></CVariant>
+			<CVendor>ARM</CVendor>
+			<CVersion>5.1.2</CVersion>
+			<DefaultRepoPath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs</DefaultRepoPath>
+			<DependentComponents xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays" />
+			<Description></Description>
+			<Files xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\arm\CMSIS\5.4.0\CMSIS\Documentation\Core\html\index.html</AbsolutePath>
+					<Attribute></Attribute>
+					<Category>doc</Category>
+					<Condition></Condition>
+					<FileContentHash i:nil="true" />
+					<FileVersion></FileVersion>
+					<Name>CMSIS/Documentation/Core/html/index.html</Name>
+					<SelectString></SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\arm\CMSIS\5.4.0\CMSIS\Core\Include\</AbsolutePath>
+					<Attribute></Attribute>
+					<Category>include</Category>
+					<Condition></Condition>
+					<FileContentHash i:nil="true" />
+					<FileVersion></FileVersion>
+					<Name>CMSIS/Core/Include/</Name>
+					<SelectString></SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+			</Files>
+			<PackName>CMSIS</PackName>
+			<PackPath>C:/Program Files (x86)/Atmel/Studio/7.0/Packs/arm/CMSIS/5.4.0/ARM.CMSIS.pdsc</PackPath>
+			<PackVersion>5.4.0</PackVersion>
+			<PresentInProject>true</PresentInProject>
+			<ReferenceConditionId>ARMv6_7_8-M Device</ReferenceConditionId>
+			<RteComponents xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+				<d4p1:string></d4p1:string>
+			</RteComponents>
+			<Status>Resolved</Status>
+			<VersionMode>Fixed</VersionMode>
+			<IsComponentInAtProject>true</IsComponentInAtProject>
+		</ProjectComponent>
+		<ProjectComponent z:Id="i2" xmlns:z="http://schemas.microsoft.com/2003/10/Serialization/">
+			<CApiVersion></CApiVersion>
+			<CBundle></CBundle>
+			<CClass>Device</CClass>
+			<CGroup>Startup</CGroup>
+			<CSub></CSub>
+			<CVariant></CVariant>
+			<CVendor>Atmel</CVendor>
+			<CVersion>1.2.0</CVersion>
+			<DefaultRepoPath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs</DefaultRepoPath>
+			<DependentComponents xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+				<d4p1:anyType z:Ref="i1" />
+			</DependentComponents>
+			<Description></Description>
+			<Files xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\atmel\SAML21_DFP\1.2.125\saml21b\include</AbsolutePath>
+					<Attribute></Attribute>
+					<Category>include</Category>
+					<Condition>C</Condition>
+					<FileContentHash i:nil="true" />
+					<FileVersion></FileVersion>
+					<Name>saml21b/include</Name>
+					<SelectString></SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\atmel\SAML21_DFP\1.2.125\saml21b\include\sam.h</AbsolutePath>
+					<Attribute></Attribute>
+					<Category>header</Category>
+					<Condition>C</Condition>
+					<FileContentHash>tUyaDQL2CUvpNPje1XBiew==</FileContentHash>
+					<FileVersion></FileVersion>
+					<Name>saml21b/include/sam.h</Name>
+					<SelectString></SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\atmel\SAML21_DFP\1.2.125\saml21b\templates\main.c</AbsolutePath>
+					<Attribute>template</Attribute>
+					<Category>source</Category>
+					<Condition>C Exe</Condition>
+					<FileContentHash>hQ+n2tKnhxvzPaygIbVlxg==</FileContentHash>
+					<FileVersion></FileVersion>
+					<Name>saml21b/templates/main.c</Name>
+					<SelectString>Main file (.c)</SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\atmel\SAML21_DFP\1.2.125\saml21b\templates\main.cpp</AbsolutePath>
+					<Attribute>template</Attribute>
+					<Category>source</Category>
+					<Condition>C Exe</Condition>
+					<FileContentHash>nU+WlKcYaWh0AWBBS+WVpA==</FileContentHash>
+					<FileVersion></FileVersion>
+					<Name>saml21b/templates/main.cpp</Name>
+					<SelectString>Main file (.cpp)</SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\atmel\SAML21_DFP\1.2.125\saml21b\gcc\system_saml21.c</AbsolutePath>
+					<Attribute>config</Attribute>
+					<Category>source</Category>
+					<Condition>GCC Exe</Condition>
+					<FileContentHash>U+bOrHkMSAjACDLHAKXn+Q==</FileContentHash>
+					<FileVersion></FileVersion>
+					<Name>saml21b/gcc/system_saml21.c</Name>
+					<SelectString></SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\atmel\SAML21_DFP\1.2.125\saml21b\gcc\gcc\startup_saml21.c</AbsolutePath>
+					<Attribute>config</Attribute>
+					<Category>source</Category>
+					<Condition>GCC Exe</Condition>
+					<FileContentHash>zijEzWB7CmllWulJu1ACzw==</FileContentHash>
+					<FileVersion></FileVersion>
+					<Name>saml21b/gcc/gcc/startup_saml21.c</Name>
+					<SelectString></SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\atmel\SAML21_DFP\1.2.125\saml21b\gcc\gcc\saml21j18b_flash.ld</AbsolutePath>
+					<Attribute>config</Attribute>
+					<Category>linkerScript</Category>
+					<Condition>GCC Exe</Condition>
+					<FileContentHash>4Sn9xSQH3dWLaW/jxl0XUw==</FileContentHash>
+					<FileVersion></FileVersion>
+					<Name>saml21b/gcc/gcc/saml21j18b_flash.ld</Name>
+					<SelectString></SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+				<d4p1:anyType i:type="FileInfo">
+					<AbsolutePath>C:/Program Files (x86)\Atmel\Studio\7.0\Packs\atmel\SAML21_DFP\1.2.125\saml21b\gcc\gcc\saml21j18b_sram.ld</AbsolutePath>
+					<Attribute>config</Attribute>
+					<Category>other</Category>
+					<Condition>GCC Exe</Condition>
+					<FileContentHash>ftBhgaPqM4tW/jKmhVu3mg==</FileContentHash>
+					<FileVersion></FileVersion>
+					<Name>saml21b/gcc/gcc/saml21j18b_sram.ld</Name>
+					<SelectString></SelectString>
+					<SourcePath></SourcePath>
+				</d4p1:anyType>
+			</Files>
+			<PackName>SAML21_DFP</PackName>
+			<PackPath>C:/Program Files (x86)/Atmel/Studio/7.0/Packs/atmel/SAML21_DFP/1.2.125/Atmel.SAML21_DFP.pdsc</PackPath>
+			<PackVersion>1.2.125</PackVersion>
+			<PresentInProject>true</PresentInProject>
+			<ReferenceConditionId>ATSAML21J18B</ReferenceConditionId>
+			<RteComponents xmlns:d4p1="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+				<d4p1:string></d4p1:string>
+			</RteComponents>
+			<Status>Resolved</Status>
+			<VersionMode>Fixed</VersionMode>
+			<IsComponentInAtProject>true</IsComponentInAtProject>
+		</ProjectComponent>
+	</ProjectComponents>
+</Store>

--- a/FastHamming.cproj
+++ b/FastHamming.cproj
@@ -1,0 +1,211 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectVersion>7.0</ProjectVersion>
+    <ToolchainName>com.Atmel.ARMGCC.C</ToolchainName>
+    <ProjectGuid>dce6c7e3-ee26-4d79-826b-08594b9ad897</ProjectGuid>
+    <avrdevice>ATSAML21J18B</avrdevice>
+    <avrdeviceseries>none</avrdeviceseries>
+    <OutputType>Executable</OutputType>
+    <Language>C</Language>
+    <OutputFileName>$(MSBuildProjectName)</OutputFileName>
+    <OutputFileExtension>.elf</OutputFileExtension>
+    <OutputDirectory>$(MSBuildProjectDirectory)\$(Configuration)</OutputDirectory>
+    <AssemblyName>FastHamming</AssemblyName>
+    <Name>FastHamming</Name>
+    <RootNamespace>FastHamming</RootNamespace>
+    <ToolchainFlavour>Native</ToolchainFlavour>
+    <KeepTimersRunning>true</KeepTimersRunning>
+    <OverrideVtor>false</OverrideVtor>
+    <CacheFlash>true</CacheFlash>
+    <ProgFlashFromRam>true</ProgFlashFromRam>
+    <RamSnippetAddress>0x20000000</RamSnippetAddress>
+    <UncachedRange />
+    <preserveEEPROM>true</preserveEEPROM>
+    <OverrideVtorValue>exception_table</OverrideVtorValue>
+    <BootSegment>2</BootSegment>
+    <ResetRule>0</ResetRule>
+    <eraseonlaunchrule>0</eraseonlaunchrule>
+    <EraseKey />
+    <AsfFrameworkConfig>
+      <framework-data xmlns="">
+        <options />
+        <configurations />
+        <files />
+        <documentation help="" />
+        <offline-documentation help="" />
+        <dependencies>
+          <content-extension eid="atmel.asf" uuidref="Atmel.ASF" version="3.47.0" />
+        </dependencies>
+      </framework-data>
+    </AsfFrameworkConfig>
+    <AAFDebugger>
+      <AAFDebugFiles>
+        <DebugFile>
+          <path>\Debug\FastHamming.lss</path>
+          <AAFSetting>
+            <Label>Lss Files</Label>
+            <Extention>.lss</Extention>
+            <Regex>^\s*(?&lt;address&gt;[a-f0-9]*):\s*.*$</Regex>
+            <DebugEnabled>true</DebugEnabled>
+            <RegexGroups>address</RegexGroups>
+            <DebuggerExpression>$pc</DebuggerExpression>
+          </AAFSetting>
+        </DebugFile>
+      </AAFDebugFiles>
+    </AAFDebugger>
+    <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
+    <avrtoolserialnumber>J41800109476</avrtoolserialnumber>
+    <avrdeviceexpectedsignature>0x1081020F</avrdeviceexpectedsignature>
+    <avrtoolinterface>SWD</avrtoolinterface>
+    <com_atmel_avrdbg_tool_atmelice>
+      <ToolOptions>
+        <InterfaceProperties>
+          <SwdClock>2000000</SwdClock>
+        </InterfaceProperties>
+        <InterfaceName>SWD</InterfaceName>
+      </ToolOptions>
+      <ToolType>com.atmel.avrdbg.tool.atmelice</ToolType>
+      <ToolNumber>J41800109476</ToolNumber>
+      <ToolName>Atmel-ICE</ToolName>
+    </com_atmel_avrdbg_tool_atmelice>
+    <avrtoolinterfaceclock>2000000</avrtoolinterfaceclock>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <ToolchainSettings>
+      <ArmGcc>
+  <armgcc.common.outputfiles.hex>True</armgcc.common.outputfiles.hex>
+  <armgcc.common.outputfiles.lss>True</armgcc.common.outputfiles.lss>
+  <armgcc.common.outputfiles.eep>True</armgcc.common.outputfiles.eep>
+  <armgcc.common.outputfiles.bin>True</armgcc.common.outputfiles.bin>
+  <armgcc.common.outputfiles.srec>True</armgcc.common.outputfiles.srec>
+  <armgcc.compiler.symbols.DefSymbols>
+    <ListValues>
+      <Value>NDEBUG</Value>
+    </ListValues>
+  </armgcc.compiler.symbols.DefSymbols>
+  <armgcc.compiler.directories.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\arm\CMSIS\5.4.0\CMSIS\Core\Include\</Value>
+      <Value>%24(PackRepoDir)\atmel\SAML21_DFP\1.2.125\saml21b\include</Value>
+    </ListValues>
+  </armgcc.compiler.directories.IncludePaths>
+  <armgcc.compiler.optimization.level>Optimize for size (-Os)</armgcc.compiler.optimization.level>
+  <armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>
+  <armgcc.compiler.warnings.AllWarnings>True</armgcc.compiler.warnings.AllWarnings>
+  <armgcc.linker.libraries.Libraries>
+    <ListValues>
+      <Value>libm</Value>
+    </ListValues>
+  </armgcc.linker.libraries.Libraries>
+  <armgcc.linker.libraries.LibrarySearchPaths>
+    <ListValues>
+      <Value>%24(ProjectDir)\Device_Startup</Value>
+    </ListValues>
+  </armgcc.linker.libraries.LibrarySearchPaths>
+  <armgcc.linker.optimization.GarbageCollectUnusedSections>True</armgcc.linker.optimization.GarbageCollectUnusedSections>
+  <armgcc.linker.miscellaneous.LinkerFlags>-Tsaml21j18b_flash.ld</armgcc.linker.miscellaneous.LinkerFlags>
+  <armgcc.assembler.general.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\arm\CMSIS\5.4.0\CMSIS\Core\Include\</Value>
+      <Value>%24(PackRepoDir)\atmel\SAML21_DFP\1.2.125\saml21b\include</Value>
+    </ListValues>
+  </armgcc.assembler.general.IncludePaths>
+  <armgcc.preprocessingassembler.general.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\arm\CMSIS\5.4.0\CMSIS\Core\Include\</Value>
+      <Value>%24(PackRepoDir)\atmel\SAML21_DFP\1.2.125\saml21b\include</Value>
+    </ListValues>
+  </armgcc.preprocessingassembler.general.IncludePaths>
+</ArmGcc>
+    </ToolchainSettings>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <ToolchainSettings>
+      <ArmGcc>
+  <armgcc.common.outputfiles.hex>True</armgcc.common.outputfiles.hex>
+  <armgcc.common.outputfiles.lss>True</armgcc.common.outputfiles.lss>
+  <armgcc.common.outputfiles.eep>True</armgcc.common.outputfiles.eep>
+  <armgcc.common.outputfiles.bin>True</armgcc.common.outputfiles.bin>
+  <armgcc.common.outputfiles.srec>True</armgcc.common.outputfiles.srec>
+  <armgcc.compiler.symbols.DefSymbols>
+    <ListValues>
+      <Value>DEBUG</Value>
+    </ListValues>
+  </armgcc.compiler.symbols.DefSymbols>
+  <armgcc.compiler.directories.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\arm\CMSIS\5.4.0\CMSIS\Core\Include\</Value>
+      <Value>%24(PackRepoDir)\atmel\SAML21_DFP\1.2.125\saml21b\include</Value>
+    </ListValues>
+  </armgcc.compiler.directories.IncludePaths>
+  <armgcc.compiler.optimization.level>Optimize (-O1)</armgcc.compiler.optimization.level>
+  <armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>
+  <armgcc.compiler.optimization.DebugLevel>Maximum (-g3)</armgcc.compiler.optimization.DebugLevel>
+  <armgcc.compiler.warnings.AllWarnings>True</armgcc.compiler.warnings.AllWarnings>
+  <armgcc.linker.libraries.Libraries>
+    <ListValues>
+      <Value>libm</Value>
+    </ListValues>
+  </armgcc.linker.libraries.Libraries>
+  <armgcc.linker.libraries.LibrarySearchPaths>
+    <ListValues>
+      <Value>%24(ProjectDir)\Device_Startup</Value>
+    </ListValues>
+  </armgcc.linker.libraries.LibrarySearchPaths>
+  <armgcc.linker.optimization.GarbageCollectUnusedSections>True</armgcc.linker.optimization.GarbageCollectUnusedSections>
+  <armgcc.linker.miscellaneous.LinkerFlags>-Tsaml21j18b_flash.ld</armgcc.linker.miscellaneous.LinkerFlags>
+  <armgcc.assembler.general.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\arm\CMSIS\5.4.0\CMSIS\Core\Include\</Value>
+      <Value>%24(PackRepoDir)\atmel\SAML21_DFP\1.2.125\saml21b\include</Value>
+    </ListValues>
+  </armgcc.assembler.general.IncludePaths>
+  <armgcc.assembler.debugging.DebugLevel>Default (-g)</armgcc.assembler.debugging.DebugLevel>
+  <armgcc.preprocessingassembler.general.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\arm\CMSIS\5.4.0\CMSIS\Core\Include\</Value>
+      <Value>%24(PackRepoDir)\atmel\SAML21_DFP\1.2.125\saml21b\include</Value>
+    </ListValues>
+  </armgcc.preprocessingassembler.general.IncludePaths>
+  <armgcc.preprocessingassembler.debugging.DebugLevel>Default (-Wa,-g)</armgcc.preprocessingassembler.debugging.DebugLevel>
+</ArmGcc>
+    </ToolchainSettings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Device_Startup\startup_saml21.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="Device_Startup\system_saml21.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="fast_hamming.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="fast_hamming.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="fast_hamming_test.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="fast_hamming_test.h">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="main.c">
+      <SubType>compile</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Device_Startup\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Device_Startup\saml21j18b_flash.ld">
+      <SubType>compile</SubType>
+    </None>
+    <None Include="Device_Startup\saml21j18b_sram.ld">
+      <SubType>compile</SubType>
+    </None>
+  </ItemGroup>
+  <Import Project="$(AVRSTUDIO_EXE_PATH)\\Vs\\Compiler.targets" />
+</Project>

--- a/fast_hamming.c
+++ b/fast_hamming.c
@@ -90,7 +90,7 @@ bool hecc_encode(const uint8_t *inbuf, size_t insize, uint8_t *outbuf, size_t *o
 
 static inline uint8_t log2uint8(uint8_t v) {
 #if 1
-    return 32 - __builtin_clz(v);
+    return 31 - __builtin_clz(v);
 #else
     register uint8_t r = 0; // result of log2(v) will go here
 

--- a/fast_hamming.c
+++ b/fast_hamming.c
@@ -1,3 +1,10 @@
+/*
+ * fast_hamming_test.c
+ *
+ * Created: 05.09.2020
+ *  Author: BenBE (https://github.com/BenBE)
+ */ 
+
 #include "fast_hamming.h"
 
 __attribute__((nonnull(1,2)))

--- a/fast_hamming.h
+++ b/fast_hamming.h
@@ -1,9 +1,31 @@
+/*
+ * fast_hamming_test.h
+ *
+ * Created: 05.09.2020
+ *  Author: BenBE (https://github.com/BenBE)
+ */ 
+
+
+#ifndef FAST_HAMMING_H_
+#define FAST_HAMMING_H_
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
+
+//////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//////////////////////////////////////////////////////////////////////////
+
+// encodes any input data. You must specify the maximum size of the output buffer, after encoding
+// this value will be update to reflect the used space. 'insize' and 'outsize' are in bytes
+// TODO: explain all parameters and the return value!
 __attribute__((nonnull(1,3,4)))
 bool hecc_encode(const uint8_t *inbuf, size_t insize, uint8_t *outbuf, size_t *outsize);
 
 __attribute__((nonnull(1,3,4)))
 bool hecc_decode(const uint8_t *inbuf, size_t insize, uint8_t *outbuf, size_t *outsize);
+
+
+#endif /* FAST_HAMMING_H_ */

--- a/fast_hamming_test.c
+++ b/fast_hamming_test.c
@@ -1,0 +1,91 @@
+/*
+ * fast_hamming_test.c
+ *
+ * Created: 07.08.2021 10:02:12
+ *  Author: nqtronix (https://github.com/nqtronix)
+ */ 
+
+
+#include "fast_hamming.h"
+#include "fast_hamming_test.h"
+
+//////////////////////////////////////////////////////////////////////////
+// Test Data
+//////////////////////////////////////////////////////////////////////////
+
+// random data sourced from: https://www.random.org/cgi-bin/randbyte?nbytes=15&format=h
+// to format the data correctly, mark the array data and use the following REGEX (excluding ""):
+// search:  "([0-9a-f]+)[\W]"
+// replace: "0x$1, "
+uint8_t data8[15] =
+{
+	0x0b, 0x28, 0x48, 0x69, 0x5e, 0xc8, 0xeb, 0x87, 0x7f, 0x28, 0xdf, 0x52, 0x03, 0xb4, 0x46, 
+};
+
+//////////////////////////////////////////////////////////////////////////
+// Functions
+//////////////////////////////////////////////////////////////////////////
+
+fast_hamming_err_m fast_hamming_test(void)
+{
+	// test result
+	fast_hamming_err_m error = FAST_HAMMING_ERR_NONE;
+	
+	// tmp storage
+	uint8_t dummy [16];						// write data here to discard
+	uint8_t outbuf [16] = {0};				// result of encoding
+	size_t outsize = sizeof(outbuf);		// length after encoding
+	
+	// encode data
+	error |= (true == hecc_encode(data8, sizeof(data8), outbuf, &outsize)) ? FAST_HAMMING_ERR_NONE : FAST_HAMMING_ERR_ENCODE;
+	const uint8_t code = outbuf[15];		// backup of parity data
+	
+	// verify no error
+	outsize = sizeof(outbuf);
+	error |= (true == hecc_decode(outbuf, sizeof(data8)+1, dummy, &outsize)) ? FAST_HAMMING_ERR_NONE : FAST_HAMMING_ERR_NOCHANGE;
+	
+	// verify data error
+	outsize = sizeof(outbuf);
+	for (uint32_t idx=0; idx < sizeof(data8)*8; idx++)
+	{
+		data8[idx>>3] ^= 1 << (idx & 0b111);
+			
+		error |= (true == hecc_decode(outbuf, sizeof(data8)+1, dummy, &outsize)) ? FAST_HAMMING_ERR_NONE : FAST_HAMMING_ERR_DATA;
+		if (outbuf[0] != data8[0])
+		{
+			outbuf[0] = data8[0];
+			error |= FAST_HAMMING_ERR_DATA_RES;
+		}
+	}
+	
+	// verify code error
+	outsize = sizeof(outbuf);
+	for (uint32_t idx=0; idx < 7; idx++)
+	{
+		outbuf[15] ^= 1<<idx;
+		error |= (true == hecc_decode(outbuf, sizeof(data8)+1, dummy, &outsize)) ? FAST_HAMMING_ERR_NONE : FAST_HAMMING_ERR_CODE;
+		
+		if (outbuf[15] != code)
+		{
+			outbuf[0] = data8[0];
+			error |= FAST_HAMMING_ERR_CODE_RES;
+		}
+	}
+	
+	// verify parity error
+	outsize = sizeof(outbuf);
+	outbuf[15] ^= 1<<7;
+	error |= (true == hecc_decode(outbuf, sizeof(data8)+1, dummy, &outsize)) ? FAST_HAMMING_ERR_NONE : FAST_HAMMING_ERR_PARITY;
+	if (outbuf[0] != data8[0])
+	{
+		outbuf[0] = data8[0];
+		error |= FAST_HAMMING_ERR_PARITY_RES;
+	}
+
+	// verify un-fixable error
+	outsize = sizeof(outbuf);
+	data8[0] ^= 3;
+	error |= (true == hecc_decode(outbuf, sizeof(data8)+1, dummy, &outsize)) ? FAST_HAMMING_ERR_NONE : FAST_HAMMING_ERR_DOUBLE;
+	
+	return error;
+}

--- a/fast_hamming_test.h
+++ b/fast_hamming_test.h
@@ -1,0 +1,39 @@
+/*
+ * fast_hamming_test.h
+ *
+ * Created: 07.08.2021 10:02:23
+ *  Author: nqtronix (https://github.com/nqtronix)
+ */ 
+
+
+#ifndef FAST_HAMMING_TEST_H_
+#define FAST_HAMMING_TEST_H_
+
+
+//////////////////////////////////////////////////////////////////////////
+// Enums & Defines
+//////////////////////////////////////////////////////////////////////////
+
+typedef enum
+{
+	FAST_HAMMING_ERR_NONE		= 0,
+	FAST_HAMMING_ERR_ENCODE		= 1<<0,		// encoding failed
+	FAST_HAMMING_ERR_NOCHANGE	= 1<<1,		// decoding of unchanged data failed
+	FAST_HAMMING_ERR_DATA		= 1<<2,		// decoding of 1 bit error in data failed
+	FAST_HAMMING_ERR_DATA_RES	= 1<<3,		// decoding of 1 bit error in data was not correctly restored
+	FAST_HAMMING_ERR_CODE		= 1<<4,		// decoding of 1 bit error in code failed
+	FAST_HAMMING_ERR_CODE_RES	= 1<<5,		// decoding of 1 bit error in code was not correctly restored
+	FAST_HAMMING_ERR_PARITY		= 1<<6,		// decoding of 1 bit error in parity failed
+	FAST_HAMMING_ERR_PARITY_RES	= 1<<7,		// decoding of 1 bit error in parity was not correctly restored
+	FAST_HAMMING_ERR_DOUBLE		= 1<<8,		// decoding of 2 bit errors was NOT detected
+} fast_hamming_err_m;	// *_m = mask; multiple values can be joined with a binary or
+
+//////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//////////////////////////////////////////////////////////////////////////
+
+fast_hamming_err_m fast_hamming_test(void);
+
+
+
+#endif /* FAST_HAMMING_TEST_H_ */

--- a/main.c
+++ b/main.c
@@ -1,0 +1,21 @@
+/*
+ * main.c
+ *
+ * Created: 07.08.2021 09:48:38
+ * Author : nqtronix (https://github.com/nqtronix)
+ */ 
+
+#include "sam.h"
+#include "fast_hamming.h"
+#include "fast_hamming_test.h"
+
+int main(void)
+{
+	// run test routine
+	volatile fast_hamming_err_m result = fast_hamming_test();
+
+	// stop point for debugger
+	asm("nop");
+
+    while (1);
+}


### PR DESCRIPTION
I think I have found another issue, the log2 implementaion is not correct. The issue is best shown with examples:

```
1: log2(0b0001) = 0; clz(0b0001) = 31
2: log2(0b0010) = 1; clz(0b0010) = 30
4: log2(0b0100) = 2; clz(0b0100) = 29
8: log2(0b1000) = 3; clz(0b1000) = 28
```

This means the formula must be `log2(x) = 31 - clz(x)`

---

If you use this fixed formula, the calculation for the bit index is also correct. This is easy to see if we fill in example values:

formula: `p2 = p1 - log2uint8(p1) - 2;`  <=> `p2 = p1 - (31-clz(p1)) - 2;`

bit 0 flipped -> index 3 = 0b0011: `3 - (31-clz(0b0011)) - 2` = `3 - (31-30) - 2` = 0
bit 1 flipped -> index 5 = 0b0101: `5 - (31-clz(0b0101)) - 2` = `5 - (31-29) - 2` = 1
bit 2 flipped -> index 6 = 0b0110: `6 - (31-clz(0b0110)) - 2` = `6 - (31-29) - 2` = 2
bit 3 flipped -> index 7 = 0b0111: `7 - (31-clz(0b0111)) - 2` = `7 - (31-29) - 2` = 3
bit 4 flipped -> index 9 = 0b1001: `9 - (31-clz(0b1001)) - 2` = `9 - (31-28) - 2` = 4

I did not verify the alternative path (#ifdef 0)
